### PR TITLE
Changing the setup.bz2 path

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -92,18 +92,25 @@ function findworkspace()
 
 function getsetup()
 {
+  # arch
+  if [[ `uname -m` =~ i[3456]86 ]]; then
+    arch=x86
+  else
+    arch=x86_64
+  fi
+
   if test "$noscripts" == "0" -a "$noupdate" == "0"
   then
     touch setup.ini
     mv setup.ini setup.ini-save
-    wget -N $mirror/setup.bz2
+    wget -N $mirror/$arch/setup.bz2
     if test -e setup.bz2 && test $? -eq 0
     then
       bunzip2 setup.bz2
       mv setup setup.ini
       echo Updated setup.ini
     else
-      wget -N $mirror/setup.ini
+      wget -N $mirror/$arch/setup.ini
       if test -e setup.ini && test $? -eq 0
       then
         echo Updated setup.ini


### PR DESCRIPTION
## Changing the setup.bz2 path
### Commit message

because
- that allow downloading setup.bz2 as intended
### Problem

`apt-cyg update` return an error because
- the setup.bz2 path is wrong

<!-- -->

```
$ apt-cyg update -m http://box-soft.com
Working directory is /setup
Mirror is http://box-soft.com
--2013-08-06 16:51:07--  http://box-soft.com/setup.bz2
Resolving box-soft.com (box-soft.com)... 204.45.81.84
Connecting to box-soft.com (box-soft.com)|204.45.81.84|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2013-08-06 16:51:08 ERROR 404: Not Found.

--2013-08-06 16:51:08--  http://box-soft.com/setup.ini
Resolving box-soft.com (box-soft.com)... 204.45.81.84
Connecting to box-soft.com (box-soft.com)|204.45.81.84|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2013-08-06 16:51:08 ERROR 404: Not Found.

Error updating setup.ini, reverting
```
### Solution

Changing the setup.bz2 path because
- that allow downloading it as intended

<!-- -->

```
$ apt-cyg update -m http://box-soft.com
Working directory is /setup
Mirror is http://box-soft.com
--2013-08-06 16:58:10--  http://box-soft.com/x86/setup.bz2
Resolving box-soft.com (box-soft.com)... 204.45.81.84
Connecting to box-soft.com (box-soft.com)|204.45.81.84|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 393796 (385K) [application/octet-stream]
Saving to: ‘setup.bz2’

100%[==========================================================================================>] 393,796      190KB/s   in 2.0s

2013-08-06 16:58:12 (190 KB/s) - ‘setup.bz2’ saved [393796/393796]

Updated setup.ini
```
### Compared to previous solution

Compared to https://github.com/cfg/apt-cyg/pull/1 this patch fix this problem

```
$ apt-cyg install bind-utils
Working directory is /c/Users/User/Downloads
Mirror is http://box-soft.com/x86
--2013-09-27 21:06:24--  http://box-soft.com/x86/setup.bz2
Resolving box-soft.com (box-soft.com)... 204.45.81.84
Connecting to box-soft.com (box-soft.com)|204.45.81.84|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 387185 (378K) [application/octet-stream]
Saving to: `setup.bz2'

100%[=========================================================================================>] 387,185     92.1K/s   in 4.2s

2013-09-27 21:06:29 (89.3 KB/s) - `setup.bz2' saved [387185/387185]

Updated setup.ini
Installing bind-utils as bind-utils...

Installing bind-utils
Found package bind-utils
--2013-09-27 21:06:29--  http://box-soft.com/x86/x86/release/bind/bind-utils/bind-utils-9.9.3-P2-1.tar.bz2
Resolving box-soft.com (box-soft.com)... 204.45.81.84
Connecting to box-soft.com (box-soft.com)|204.45.81.84|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2013-09-27 21:06:30 ERROR 404: Not Found.

md5sum: bind-utils-9.9.3-P2-1.tar.bz2: No such file or directory
/usr/local/bin/apt-cyg: line 457: test: 8f93155e020214996ee94ba736fdd148: unary operator expected
MD5 sum did not match, exiting
```
### Test

The code is tested with this bash command

```
[[ i686 =~ i[3456]86 ]]; echo $?
0

[[ x86_64 =~ i[3456]86 ]]; echo $?
1
```

that return 0 when the statement is true

```
true; echo $?
0

false; echo $?
1
```
### Machine type accidentally hardcoded

> https://github.com/john-peterson/apt-cyg/commit/8f77dd5704e1e5ac86aca9ca9361debc993aaf91#commitcomment-5411571
> 
> How about using "uname -m" to determine x86 vs x86_64?

That's my intention

I've fixed it
